### PR TITLE
bump package dalle-node version to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "dalle-node": "1.0.3",
+    "dalle-node": "1.0.5",
     "next": "12.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
from openai: "4 images per prompt: Starting later today, DALL·E will return four images instead of six. This allows more people to experience DALL·E by lessening the strain on our capacity."

this is adjusted in the package